### PR TITLE
test(phase-h.3): Extensions.HumanTasks + Approvals TinyBDD layer (~26 scenarios)

### DIFF
--- a/WorkflowFramework.slnx
+++ b/WorkflowFramework.slnx
@@ -90,6 +90,7 @@
     <Project Path="tests/WorkflowFramework.Extensions.DependencyInjection.Tests/WorkflowFramework.Extensions.DependencyInjection.Tests.csproj" />
     <Project Path="tests/WorkflowFramework.Extensions.AI.Tests/WorkflowFramework.Extensions.AI.Tests.csproj" />
     <Project Path="tests/WorkflowFramework.Extensions.Agents.Tests/WorkflowFramework.Extensions.Agents.Tests.csproj" />
+    <Project Path="tests/WorkflowFramework.Extensions.HumanTasks.Tests/WorkflowFramework.Extensions.HumanTasks.Tests.csproj" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/WorkflowFramework.Benchmarks/WorkflowFramework.Benchmarks.csproj" />

--- a/tests/WorkflowFramework.Extensions.Approvals.Tests/ApprovalsRequestBuilderScenarios.cs
+++ b/tests/WorkflowFramework.Extensions.Approvals.Tests/ApprovalsRequestBuilderScenarios.cs
@@ -1,0 +1,173 @@
+using FluentAssertions;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WorkflowFramework.Extensions.Approvals;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WorkflowFramework.Extensions.Approvals.Tests;
+
+/// <summary>
+/// TinyBDD scenarios for <see cref="ApprovalRequestBuilder"/>.
+/// These complement the existing plain-xUnit tests in the project.
+/// </summary>
+[Feature("ApprovalRequestBuilder — fluent builder for approval requests")]
+public class ApprovalsRequestBuilderScenarios : TinyBddXunitBase
+{
+    public ApprovalsRequestBuilderScenarios(ITestOutputHelper output) : base(output) { }
+
+    [Scenario("Build with only title produces request with default values"), Fact]
+    public async Task Build_WithTitle_ProducesDefaults()
+    {
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("Deploy to prod")
+            .Build();
+
+        await Given("builder with only title set", () => request)
+            .Then("request has the given title and required=1 and non-empty id", r =>
+            {
+                r.Title.Should().Be("Deploy to prod");
+                r.RequiredApprovers.Should().Be(1);
+                r.CorrelationId.Should().NotBeNullOrEmpty();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WithTitle null throws ArgumentNullException"), Fact]
+    public async Task WithTitle_Null_ThrowsArgumentNullException()
+    {
+        Exception? caught = null;
+        try { new ApprovalRequestBuilder().WithTitle(null!); }
+        catch (Exception ex) { caught = ex; }
+
+        await Given("null title passed to WithTitle", () => caught)
+            .Then("ArgumentNullException is thrown", ex =>
+            {
+                ex.Should().BeOfType<ArgumentNullException>();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WithTitle whitespace throws ArgumentException"), Fact]
+    public async Task WithTitle_Whitespace_ThrowsArgumentException()
+    {
+        Exception? caught = null;
+        try { new ApprovalRequestBuilder().WithTitle("   "); }
+        catch (Exception ex) { caught = ex; }
+
+        await Given("whitespace title", () => caught)
+            .Then("ArgumentException is thrown", ex =>
+            {
+                ex.Should().BeOfType<ArgumentException>();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("RequiringApprovers sets required approval count"), Fact]
+    public async Task RequiringApprovers_SetsCount()
+    {
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("T")
+            .RequiringApprovers(3)
+            .Build();
+
+        await Given("RequiringApprovers(3)", () => request.RequiredApprovers)
+            .Then("RequiredApprovers is 3", count =>
+            {
+                count.Should().Be(3);
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WithTimeout sets the timeout on the request"), Fact]
+    public async Task WithTimeout_SetsTimeout()
+    {
+        var timeout = TimeSpan.FromHours(2);
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("T")
+            .WithTimeout(timeout)
+            .Build();
+
+        await Given("WithTimeout(2h)", () => request.Timeout)
+            .Then("Timeout is 2 hours", t =>
+            {
+                t.Should().Be(timeout);
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("AllowedFor sets allowed roles on the request"), Fact]
+    public async Task AllowedFor_SetsRoles()
+    {
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("T")
+            .AllowedFor("admin", "manager")
+            .Build();
+
+        await Given("AllowedFor('admin', 'manager')", () => request.AllowedRoles)
+            .Then("AllowedRoles contains both roles", roles =>
+            {
+                roles.Should().Contain("admin").And.Contain("manager");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WithContext stores key-value pair in request context"), Fact]
+    public async Task WithContext_StoresKeyValue()
+    {
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("T")
+            .WithContext("env", "production")
+            .Build();
+
+        await Given("WithContext('env', 'production')", () => request.Context)
+            .Then("context contains env=production", ctx =>
+            {
+                ctx.Should().ContainKey("env");
+                ctx["env"].Should().Be("production");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("Builder can be reused after Build"), Fact]
+    public async Task Builder_CanBeReusedAfterBuild()
+    {
+        var builder = new ApprovalRequestBuilder().WithTitle("First");
+        var r1 = builder.Build();
+        builder.WithTitle("Second");
+        var r2 = builder.Build();
+
+        await Given("builder used twice with different titles", () => (r1.Title, r2.Title))
+            .Then("each build has its own title", t =>
+            {
+                t.Item1.Should().Be("First");
+                t.Item2.Should().Be("Second");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WithCorrelationId sets the correlation ID on the request"), Fact]
+    public async Task WithCorrelationId_SetsId()
+    {
+        var request = new ApprovalRequestBuilder()
+            .WithTitle("T")
+            .WithCorrelationId("my-correlation-123")
+            .Build();
+
+        await Given("WithCorrelationId('my-correlation-123')", () => request.CorrelationId)
+            .Then("CorrelationId is 'my-correlation-123'", id =>
+            {
+                id.Should().Be("my-correlation-123");
+                return true;
+            })
+            .AssertPassed();
+    }
+}

--- a/tests/WorkflowFramework.Extensions.Approvals.Tests/WorkflowFramework.Extensions.Approvals.Tests.csproj
+++ b/tests/WorkflowFramework.Extensions.Approvals.Tests/WorkflowFramework.Extensions.Approvals.Tests.csproj
@@ -8,6 +8,8 @@
     <ProjectReference Include="..\..\src\WorkflowFramework.Extensions.Approvals.Abstractions\WorkflowFramework.Extensions.Approvals.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="TinyBDD" />
+    <PackageReference Include="TinyBDD.Xunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/WorkflowFramework.Extensions.HumanTasks.Tests/HumanTasks/HumanTaskStepScenarios.cs
+++ b/tests/WorkflowFramework.Extensions.HumanTasks.Tests/HumanTasks/HumanTaskStepScenarios.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using NSubstitute;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WorkflowFramework.Extensions.HumanTasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WorkflowFramework.Extensions.HumanTasks.Tests.HumanTasks;
+
+[Feature("HumanTaskStep — workflow step that pauses for human input")]
+public class HumanTaskStepScenarios : TinyBddXunitBase
+{
+    public HumanTaskStepScenarios(ITestOutputHelper output) : base(output) { }
+
+    private static ITaskInbox MakeAutoCompleteInbox(string outcome = "approved")
+    {
+        var inbox = Substitute.For<ITaskInbox>();
+        var created = new HumanTask { Title = "Review", Assignee = "alice" };
+        inbox.CreateTaskAsync(Arg.Any<HumanTask>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var t = ci.ArgAt<HumanTask>(0);
+                t.Outcome = outcome;
+                return Task.FromResult(t);
+            });
+        inbox.WaitForCompletionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var completedTask = new HumanTask { Id = ci.ArgAt<string>(0), Outcome = outcome, Status = HumanTaskStatus.Approved };
+                return Task.FromResult(completedTask);
+            });
+        return inbox;
+    }
+
+    [Scenario("Default step name uses task title"), Fact]
+    public async Task DefaultStepName_UsesTitleInName()
+    {
+        var options = new HumanTaskOptions { Title = "Review Document", Assignee = "alice", Timeout = TimeSpan.FromMinutes(1) };
+        var step = new HumanTaskStep(MakeAutoCompleteInbox(), options);
+
+        await Given("HumanTaskStep with Title='Review Document'", () => step.Name)
+            .Then("Name contains the title", name =>
+            {
+                name.Should().Contain("Review Document");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("Custom step name from options is used"), Fact]
+    public async Task CustomStepName_FromOptions()
+    {
+        var options = new HumanTaskOptions { StepName = "MyHumanTask", Title = "T", Assignee = "bob", Timeout = TimeSpan.FromMinutes(1) };
+        var step = new HumanTaskStep(MakeAutoCompleteInbox(), options);
+
+        await Given("HumanTaskStep with StepName='MyHumanTask'", () => step.Name)
+            .Then("Name is 'MyHumanTask'", name =>
+            {
+                name.Should().Be("MyHumanTask");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("ExecuteAsync stores task ID in context properties"), Fact]
+    public async Task ExecuteAsync_StoresTaskId()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var options = new HumanTaskOptions { Title = "Sign Off", Assignee = "alice", Timeout = TimeSpan.FromSeconds(5) };
+        var step = new HumanTaskStep(inbox, options);
+        var context = new WorkflowContext();
+
+        // Complete the task concurrently so Wait resolves
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(30);
+            var tasks = await inbox.GetTasksForAssigneeAsync("alice");
+            if (tasks.Count > 0) await inbox.CompleteTaskAsync(tasks[0].Id, "approved");
+        });
+
+        await step.ExecuteAsync(context);
+
+        await Given("HumanTaskStep executed with InMemoryTaskInbox", () => context.Properties)
+            .Then("context contains HumanTask(Sign Off).TaskId", props =>
+            {
+                props.Keys.Should().Contain(k => k.Contains("TaskId"));
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("ExecuteAsync stores outcome in context properties"), Fact]
+    public async Task ExecuteAsync_StoresOutcome()
+    {
+        var inbox = MakeAutoCompleteInbox("approved");
+        var options = new HumanTaskOptions { Title = "Review", Assignee = "alice", Timeout = TimeSpan.FromSeconds(1) };
+        var step = new HumanTaskStep(inbox, options);
+        var context = new WorkflowContext();
+
+        await step.ExecuteAsync(context);
+
+        await Given("HumanTaskStep completed with 'approved' outcome", () => context.Properties)
+            .Then("HumanTask(Review).Outcome is stored", props =>
+            {
+                props.Keys.Should().Contain(k => k.Contains("Outcome"));
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("Null inbox throws ArgumentNullException"), Fact]
+    public async Task NullInbox_Throws()
+    {
+        Exception? caught = null;
+        try { _ = new HumanTaskStep(null!, new HumanTaskOptions()); }
+        catch (Exception ex) { caught = ex; }
+
+        await Given("null inbox passed to constructor", () => caught)
+            .Then("ArgumentNullException thrown", ex =>
+            {
+                ex.Should().BeOfType<ArgumentNullException>();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("Null options throws ArgumentNullException"), Fact]
+    public async Task NullOptions_Throws()
+    {
+        var inbox = MakeAutoCompleteInbox();
+        Exception? caught = null;
+        try { _ = new HumanTaskStep(inbox, null!); }
+        catch (Exception ex) { caught = ex; }
+
+        await Given("null options passed to constructor", () => caught)
+            .Then("ArgumentNullException thrown", ex =>
+            {
+                ex.Should().BeOfType<ArgumentNullException>();
+                return true;
+            })
+            .AssertPassed();
+    }
+}

--- a/tests/WorkflowFramework.Extensions.HumanTasks.Tests/HumanTasks/InMemoryTaskInboxScenarios.cs
+++ b/tests/WorkflowFramework.Extensions.HumanTasks.Tests/HumanTasks/InMemoryTaskInboxScenarios.cs
@@ -1,0 +1,250 @@
+using FluentAssertions;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WorkflowFramework.Extensions.HumanTasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WorkflowFramework.Extensions.HumanTasks.Tests.HumanTasks;
+
+[Feature("InMemoryTaskInbox — in-memory human task store")]
+public class InMemoryTaskInboxScenarios : TinyBddXunitBase
+{
+    public InMemoryTaskInboxScenarios(ITestOutputHelper output) : base(output) { }
+
+    private static HumanTask MakeTask(string assignee = "alice", string title = "Review") =>
+        new HumanTask { Assignee = assignee, Title = title, WorkflowId = "wf-1" };
+
+    [Scenario("CreateTaskAsync stores and returns the task"), Fact]
+    public async Task CreateTask_StoresTask()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        var created = await inbox.CreateTaskAsync(task);
+
+        await Given("a new task created", () => created)
+            .Then("returned task is the same instance", t =>
+            {
+                t.Should().BeSameAs(task);
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("GetTaskAsync returns the stored task"), Fact]
+    public async Task GetTask_ReturnsStoredTask()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        var found = await inbox.GetTaskAsync(task.Id);
+
+        await Given("task created then retrieved by id", () => found)
+            .Then("task is not null and has same id", t =>
+            {
+                t.Should().NotBeNull();
+                t!.Id.Should().Be(task.Id);
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("GetTaskAsync returns null for unknown id"), Fact]
+    public async Task GetTask_UnknownId_ReturnsNull()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var result = await inbox.GetTaskAsync("no-such-id");
+
+        await Given("inbox with no tasks", () => result)
+            .Then("null is returned", r =>
+            {
+                r.Should().BeNull();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("GetTasksForAssigneeAsync returns only tasks for that assignee"), Fact]
+    public async Task GetTasksForAssignee_ReturnsCorrectTasks()
+    {
+        var inbox = new InMemoryTaskInbox();
+        await inbox.CreateTaskAsync(MakeTask("alice", "T1"));
+        await inbox.CreateTaskAsync(MakeTask("alice", "T2"));
+        await inbox.CreateTaskAsync(MakeTask("bob", "T3"));
+
+        var aliceTasks = await inbox.GetTasksForAssigneeAsync("alice");
+
+        await Given("two alice tasks and one bob task", () => aliceTasks)
+            .Then("alice gets exactly 2 tasks", tasks =>
+            {
+                tasks.Should().HaveCount(2);
+                tasks.Should().OnlyContain(t => t.Assignee == "alice");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("CompleteTaskAsync with 'approved' sets status to Approved"), Fact]
+    public async Task CompleteTask_Approved_SetsStatus()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        await inbox.CompleteTaskAsync(task.Id, "approved");
+
+        await Given("task completed with outcome 'approved'", () => task)
+            .Then("task.Status is Approved", t =>
+            {
+                t.Status.Should().Be(HumanTaskStatus.Approved);
+                t.Outcome.Should().Be("approved");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("CompleteTaskAsync with 'rejected' sets status to Rejected"), Fact]
+    public async Task CompleteTask_Rejected_SetsStatus()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        await inbox.CompleteTaskAsync(task.Id, "rejected");
+
+        await Given("task completed with outcome 'rejected'", () => task)
+            .Then("task.Status is Rejected", t =>
+            {
+                t.Status.Should().Be(HumanTaskStatus.Rejected);
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("CompleteTaskAsync with custom outcome sets status to Completed"), Fact]
+    public async Task CompleteTask_CustomOutcome_SetsCompleted()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        await inbox.CompleteTaskAsync(task.Id, "skipped");
+
+        await Given("task completed with custom outcome 'skipped'", () => task)
+            .Then("task.Status is Completed and outcome is 'skipped'", t =>
+            {
+                t.Status.Should().Be(HumanTaskStatus.Completed);
+                t.Outcome.Should().Be("skipped");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("CompleteTaskAsync merges extra data into task"), Fact]
+    public async Task CompleteTask_MergesData()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        await inbox.CompleteTaskAsync(task.Id, "approved",
+            new Dictionary<string, object?> { ["comment"] = "LGTM" });
+
+        await Given("complete call with extra data", () => task.Data)
+            .Then("data contains the extra key", d =>
+            {
+                d.Should().ContainKey("comment");
+                d["comment"].Should().Be("LGTM");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("DelegateTaskAsync sets DelegatedTo on the task"), Fact]
+    public async Task DelegateTask_SetsDelegatedTo()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask("alice");
+        await inbox.CreateTaskAsync(task);
+
+        await inbox.DelegateTaskAsync(task.Id, "carol");
+
+        await Given("task delegated to carol", () => task.DelegatedTo)
+            .Then("DelegatedTo is 'carol'", dt =>
+            {
+                dt.Should().Be("carol");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("CreateTaskAsync with null task throws ArgumentNullException"), Fact]
+    public async Task CreateTask_NullTask_Throws()
+    {
+        var inbox = new InMemoryTaskInbox();
+        Exception? caught = null;
+        try { await inbox.CreateTaskAsync(null!); }
+        catch (Exception ex) { caught = ex; }
+
+        await Given("null task passed to CreateTaskAsync", () => caught)
+            .Then("ArgumentNullException thrown", ex =>
+            {
+                ex.Should().BeOfType<ArgumentNullException>();
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WaitForCompletionAsync resolves when task is completed concurrently"), Fact]
+    public async Task WaitForCompletion_ResolvesOnCompletion()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        // Fire off completion after a tiny delay
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            await inbox.CompleteTaskAsync(task.Id, "done");
+        });
+
+        var completed = await inbox.WaitForCompletionAsync(task.Id, TimeSpan.FromSeconds(5));
+
+        await Given("task completed concurrently during wait", () => completed)
+            .Then("WaitForCompletion returns the completed task", t =>
+            {
+                t.Should().NotBeNull();
+                t.Outcome.Should().Be("done");
+                return true;
+            })
+            .AssertPassed();
+    }
+
+    [Scenario("WaitForCompletionAsync times out when task is not completed"), Fact]
+    public async Task WaitForCompletion_TimesOut()
+    {
+        var inbox = new InMemoryTaskInbox();
+        var task = MakeTask();
+        await inbox.CreateTaskAsync(task);
+
+        Exception? caught = null;
+        try
+        {
+            await inbox.WaitForCompletionAsync(task.Id, TimeSpan.FromMilliseconds(50));
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+
+        await Given("task not completed within timeout", () => caught)
+            .Then("a TimeoutException or OperationCanceledException is thrown", ex =>
+            {
+                ex.Should().NotBeNull();
+                return true;
+            })
+            .AssertPassed();
+    }
+}

--- a/tests/WorkflowFramework.Extensions.HumanTasks.Tests/WorkflowFramework.Extensions.HumanTasks.Tests.csproj
+++ b/tests/WorkflowFramework.Extensions.HumanTasks.Tests/WorkflowFramework.Extensions.HumanTasks.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>WorkflowFramework.Extensions.HumanTasks.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Source projects under test -->
+    <ProjectReference Include="..\..\src\WorkflowFramework\WorkflowFramework.csproj" />
+    <ProjectReference Include="..\..\src\WorkflowFramework.Extensions.HumanTasks\WorkflowFramework.Extensions.HumanTasks.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Test frameworks -->
+    <PackageReference Include="TinyBDD" />
+    <PackageReference Include="TinyBDD.Xunit" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+</Project>

--- a/tests/WorkflowFramework.Extensions.HumanTasks.Tests/packages.lock.json
+++ b/tests/WorkflowFramework.Extensions.HumanTasks.Tests/packages.lock.json
@@ -1,0 +1,816 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "iri1druxHPUAvaFqTUKJG7NOHwnOLmWwfDorgezZWpeBWBJmk2o8niI7jL7zW9TEFGnUpMJi/JLG6FXgr3cM3A=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "TinyBDD": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "H9FEUkilavosn+wNDUItTPxOYRtQXzyt0dz+1wTyUKeijvois0FX2fkHEde08ockkOpebqffJxSleIH+7jZe7w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "TinyBDD.Xunit": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "DgqB3Il3xiidn065cOga4HbyXWRV3hdgrKQKWThaXCWH40XkyWMt6ZttRuVs4LgFf73OSIsgxjrt3Tm7731O1g==",
+        "dependencies": {
+          "TinyBDD": "0.19.16",
+          "xunit.abstractions": "2.0.3",
+          "xunit.extensibility.core": "2.9.3"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "K9O9TOzugqOo4LJ87uuq1VG8RAqGp20Ng85Wx932oT5LNBkIgeeGYubVW5UMnOOTanFNbGavmbuYrJr4INzSwg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "workflowframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.5, )",
+          "PatternKit.Core": "[0.105.0, )"
+        }
+      },
+      "workflowframework.extensions.humantasks": {
+        "type": "Project",
+        "dependencies": {
+          "WorkflowFramework": "[1.0.0, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "PatternKit.Core": {
+        "type": "CentralTransitive",
+        "requested": "[0.105.0, )",
+        "resolved": "0.105.0",
+        "contentHash": "ajdoXIVxeDeTi1NhS0ykTQHk4u/FpdvYrGx9DKvpwzc3z65rSBIWSOLn1vOG2O2tYnZQTxaDC3TSno1MyLhjBg=="
+      }
+    },
+    "net8.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "iri1druxHPUAvaFqTUKJG7NOHwnOLmWwfDorgezZWpeBWBJmk2o8niI7jL7zW9TEFGnUpMJi/JLG6FXgr3cM3A=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "TinyBDD": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "H9FEUkilavosn+wNDUItTPxOYRtQXzyt0dz+1wTyUKeijvois0FX2fkHEde08ockkOpebqffJxSleIH+7jZe7w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "TinyBDD.Xunit": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "DgqB3Il3xiidn065cOga4HbyXWRV3hdgrKQKWThaXCWH40XkyWMt6ZttRuVs4LgFf73OSIsgxjrt3Tm7731O1g==",
+        "dependencies": {
+          "TinyBDD": "0.19.16",
+          "xunit.abstractions": "2.0.3",
+          "xunit.extensibility.core": "2.9.3"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "K9O9TOzugqOo4LJ87uuq1VG8RAqGp20Ng85Wx932oT5LNBkIgeeGYubVW5UMnOOTanFNbGavmbuYrJr4INzSwg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "System.Diagnostics.DiagnosticSource": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "workflowframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.5, )",
+          "PatternKit.Core": "[0.105.0, )"
+        }
+      },
+      "workflowframework.extensions.humantasks": {
+        "type": "Project",
+        "dependencies": {
+          "WorkflowFramework": "[1.0.0, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "System.Diagnostics.DiagnosticSource": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "PatternKit.Core": {
+        "type": "CentralTransitive",
+        "requested": "[0.105.0, )",
+        "resolved": "0.105.0",
+        "contentHash": "ajdoXIVxeDeTi1NhS0ykTQHk4u/FpdvYrGx9DKvpwzc3z65rSBIWSOLn1vOG2O2tYnZQTxaDC3TSno1MyLhjBg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "CCbzHQ26L3jskdwHh+4bxxW84lUMIrAAmeSlpO69AlrQV0DKbj1/I+feLaLSuZeqXPr9UlSy0OcgZoXOk2a6/g=="
+      }
+    },
+    "net9.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "iri1druxHPUAvaFqTUKJG7NOHwnOLmWwfDorgezZWpeBWBJmk2o8niI7jL7zW9TEFGnUpMJi/JLG6FXgr3cM3A=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "TinyBDD": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "H9FEUkilavosn+wNDUItTPxOYRtQXzyt0dz+1wTyUKeijvois0FX2fkHEde08ockkOpebqffJxSleIH+7jZe7w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "TinyBDD.Xunit": {
+        "type": "Direct",
+        "requested": "[0.19.16, )",
+        "resolved": "0.19.16",
+        "contentHash": "DgqB3Il3xiidn065cOga4HbyXWRV3hdgrKQKWThaXCWH40XkyWMt6ZttRuVs4LgFf73OSIsgxjrt3Tm7731O1g==",
+        "dependencies": {
+          "TinyBDD": "0.19.16",
+          "xunit.abstractions": "2.0.3",
+          "xunit.extensibility.core": "2.9.3"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "K9O9TOzugqOo4LJ87uuq1VG8RAqGp20Ng85Wx932oT5LNBkIgeeGYubVW5UMnOOTanFNbGavmbuYrJr4INzSwg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "System.Diagnostics.DiagnosticSource": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "workflowframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.5, )",
+          "PatternKit.Core": "[0.105.0, )"
+        }
+      },
+      "workflowframework.extensions.humantasks": {
+        "type": "Project",
+        "dependencies": {
+          "WorkflowFramework": "[1.0.0, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "System.Diagnostics.DiagnosticSource": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "PatternKit.Core": {
+        "type": "CentralTransitive",
+        "requested": "[0.105.0, )",
+        "resolved": "0.105.0",
+        "contentHash": "ajdoXIVxeDeTi1NhS0ykTQHk4u/FpdvYrGx9DKvpwzc3z65rSBIWSOLn1vOG2O2tYnZQTxaDC3TSno1MyLhjBg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "CCbzHQ26L3jskdwHh+4bxxW84lUMIrAAmeSlpO69AlrQV0DKbj1/I+feLaLSuZeqXPr9UlSy0OcgZoXOk2a6/g=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New TinyBDD project for `Extensions.HumanTasks` (18 scenarios)
- TinyBDD supplement layer added to existing `Extensions.Approvals.Tests` (8 new TinyBDD scenarios)
- 26 total new scenarios, all green on net8.0, net9.0, net10.0

## Changes
**New: `tests/WorkflowFramework.Extensions.HumanTasks.Tests/`**
- `InMemoryTaskInboxScenarios` — 11 scenarios: create, get by ID, null return, assignee filter, approve/reject/custom outcome, data merge, delegate, wait-on-completion, timeout
- `HumanTaskStepScenarios` — 7 scenarios: default name (uses title), custom step name, stores TaskId in context, stores Outcome, null inbox guard, null options guard

**Approvals.Tests supplement: `ApprovalsRequestBuilderScenarios`** — 8 TinyBDD scenarios:
- Build with title → correct defaults, RequiredApprovers=1
- WithTitle null/whitespace → ArgumentNullException/ArgumentException
- RequiringApprovers(3) → RequiredApprovers=3
- WithTimeout(2h) → Timeout set
- AllowedFor → AllowedRoles populated
- WithContext → context key stored
- Builder reuse after Build
- WithCorrelationId → CorrelationId set

## Test plan
- [x] `dotnet test` green on net8.0, net9.0, net10.0
- [x] No public API changes (additive test files only)
- [x] HumanTasks.Tests added to `WorkflowFramework.slnx`
- [x] TinyBDD packages added to existing Approvals.Tests (backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)